### PR TITLE
fix: Use pageSpeedApiKey state variable in handleMeasure

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -9,7 +9,6 @@ import Auth from './components/Auth.tsx';
 import VerifyEmail from './components/VerifyEmail.tsx';
 import UserProfile from './components/UserProfile.tsx';
 import { useCleaner } from './hooks/useCleaner.ts';
-import { useUserData } from './hooks/useUserData.ts';
 import { generateOptimizationPlan, generateComparisonAnalysis } from './services/geminiService.ts';
 import { fetchPageSpeedReport } from './services/pageSpeedService.ts';
 import { Recommendation, Session, ImpactSummary } from './types.ts';
@@ -339,7 +338,7 @@ const App = () => {
 
   const handleMeasure = async () => {
     if (!url) { setApiError('Please enter a URL to measure.'); return; }
-    if (!userData.pageSpeedApiKey) { setApiError('Please provide and save your PageSpeed API Key to measure speed.'); return; }
+    if (!pageSpeedApiKey) { setApiError('Please provide and save your PageSpeed API Key to measure speed.'); return; }
     
     setIsMeasuring(true);
     setApiError('');


### PR DESCRIPTION
This commit corrects the `handleMeasure` function to use the `pageSpeedApiKey` state variable directly, instead of the `userData` hook. This resolves an issue where the PageSpeed API key was not being correctly recognized, even after being saved.

The `useUserData` hook has also been removed from `App.tsx` as it is no longer needed there.