### PR TITLE
fix: Use geminiApiKey state variable in handleMeasure

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -403,14 +403,14 @@ const App = () => {
                 setCurrentSession(null);
                 
                 setIsGeneratingPlan(true);
-                const analysis = await generateComparisonAnalysis(userData.geminiApiKey, pageSpeedBefore, newReport);
+                const analysis = await generateComparisonAnalysis(geminiApiKey, pageSpeedBefore, newReport);
                 setComparisonAnalysis(analysis);
             }
 
         } else {
             setPageSpeedBefore(newReport);
             setIsGeneratingPlan(true);
-            const plan = await generateOptimizationPlan(userData.geminiApiKey, newReport);
+            const plan = await generateOptimizationPlan(geminiApiKey, newReport);
             setOptimizationPlan(plan);
         }
     } catch (error: any) {


### PR DESCRIPTION
This commit corrects the `handleMeasure` function to use the `geminiApiKey` state variable directly, instead of the `userData` hook. This resolves an issue where the `userData` was not defined, causing a `ReferenceError`.