### PR TITLE
fix: Use pageSpeedApiKey state variable in fetchPageSpeedReport

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -360,7 +360,7 @@ const App = () => {
     }
     
     try {
-        const newReport = await fetchPageSpeedReport(userData.pageSpeedApiKey, url);
+        const newReport = await fetchPageSpeedReport(pageSpeedApiKey, url);
 
         if (pageSpeedBefore) {
             setPageSpeedAfter(newReport);


### PR DESCRIPTION
This commit corrects the `fetchPageSpeedReport` call in the `handleMeasure` function to use the `pageSpeedApiKey` state variable directly, instead of the `userData` hook. This resolves the final `ReferenceError` in the `handleMeasure` function.