### PR TITLE
feat: Implement free trial logic

### DIFF
--- a/api/free-measure.ts
+++ b/api/free-measure.ts
@@ -1,0 +1,30 @@
+import { fetchPageSpeedReport } from '../services/pageSpeedService';
+import { generateOptimizationPlan } from '../services/geminiService';
+
+export async function POST(request: Request): Promise<Response> {
+  const { urlToScan } = await request.json();
+  const pageSpeedApiKey = process.env.DEFAULT_PAGESPEED_API_KEY;
+  const geminiApiKey = process.env.DEFAULT_GEMINI_API_KEY;
+
+  if (!pageSpeedApiKey || !geminiApiKey) {
+    return new Response('Default API keys are not configured.', { status: 500 });
+  }
+
+  try {
+    const pageSpeedReport = await fetchPageSpeedReport(pageSpeedApiKey, urlToScan);
+    const optimizationPlan = await generateOptimizationPlan(geminiApiKey, pageSpeedReport);
+
+    return new Response(JSON.stringify({ pageSpeedReport, optimizationPlan }), {
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+  } catch (error: any) {
+    return new Response(JSON.stringify({ error: error.message }), {
+      status: 500,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+  }
+}


### PR DESCRIPTION
This commit introduces a free trial logic to the application. The default API keys are now stored securely in the backend and accessed through a new API route `/api/free-measure`.

The changes include:
- A new API route `api/free-measure.ts` to handle free measurements.
- The `handleMeasure` function in `App.tsx` has been updated to call the new API route when you have not provided your own API keys.
- The UI has been updated to reflect the free trial status.