### PR TITLE
feat: Remove API key input fields from frontend

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -205,12 +205,6 @@ const App = () => {
   const [authLoading, setAuthLoading] = useState(true);
   const [url, setUrl] = useState('');
   
-  const [pageSpeedApiKey, setPageSpeedApiKey] = useState('');
-  const [geminiApiKey, setGeminiApiKey] = useState('');
-
-  const [isEditingPageSpeedKey, setIsEditingPageSpeedKey] = useState(true);
-  const [isEditingGeminiKey, setIsEditingGeminiKey] = useState(true);
-  const [isSaving, setIsSaving] = useState<{gemini: boolean, pagespeed: boolean}>({gemini: false, pagespeed: false});
   
   const [isMeasuring, setIsMeasuring] = useState(false);
   const [pageSpeedBefore, setPageSpeedBefore] = useState(null);
@@ -276,69 +270,6 @@ const App = () => {
   }, [user]);
 
 
-  const handleDeleteKeys = async (keyType: 'gemini' | 'pagespeed') => {
-      if (!user) return;
-      setIsSaving(prev => ({...prev, [keyType]: true}));
-      try {
-          const res = await fetch(`/api/user-data?userId=${user.uid}`, {
-              method: 'DELETE',
-          });
-
-          if (!res.ok) {
-              const errorData = await res.json().catch(() => ({ message: 'An unknown error occurred while deleting.' }));
-              throw new Error(errorData.message);
-          }
-
-          if (keyType === 'gemini') {
-              setGeminiApiKey('');
-              setIsEditingGeminiKey(true);
-          } else if (keyType === 'pagespeed') {
-              setPageSpeedApiKey('');
-              setIsEditingPageSpeedKey(true);
-          }
-
-      } catch (error: any) {
-          console.error("Failed to delete keys:", error);
-          setApiError(`Could not delete keys: ${error.message}`);
-      } finally {
-          setIsSaving(prev => ({...prev, [keyType]: false}));
-      }
-  };
-
-  const handleSaveKeys = async (keyType: 'gemini' | 'pagespeed') => {
-      if (!user) return;
-      setIsSaving(prev => ({...prev, [keyType]: true}));
-      try {
-          const res = await fetch(`/api/user-data?userId=${user.uid}`, {
-              method: 'POST',
-              headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify({
-                  geminiApiKey: keyType === 'gemini' ? geminiApiKey : undefined,
-                  pageSpeedApiKey: keyType === 'pagespeed' ? pageSpeedApiKey : undefined,
-              })
-          });
-
-          if (!res.ok) {
-              const errorData = await res.json().catch(() => ({ message: 'An unknown error occurred while saving.' }));
-              throw new Error(errorData.message);
-          }
-
-          if (keyType === 'pagespeed' && pageSpeedApiKey) {
-              setIsEditingPageSpeedKey(false);
-              setPageSpeedApiKey('');
-          }
-          if (keyType === 'gemini' && geminiApiKey) {
-              setIsEditingGeminiKey(false);
-              setGeminiApiKey('');
-          }
-
-      } catch (error: any) {
-          console.error("Failed to save keys:", error);
-          setApiError(`Could not save keys: ${error.message}`);
-      } finally {
-          setIsSaving(prev => ({...prev, [keyType]: false}));
-      }
-  };
 
   const handleMeasure = async () => {
     if (!url) { setApiError('Please enter a URL to measure.'); return; }
@@ -347,112 +278,29 @@ const App = () => {
     setApiError('');
     setSessionLoadError('');
 
-    if (!pageSpeedApiKey) {
-      // Free trial logic
-      try {
-        const idToken = await user?.getIdToken();
-        const response = await fetch('/api/free-measure', {
-          method: 'POST',
-          headers: {
-            'Authorization': `Bearer ${idToken}`,
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify({ urlToScan: url }),
-        });
-
-        if (!response.ok) {
-          const errorData = await response.json();
-          throw new Error(errorData.error || 'Failed to fetch free measurement.');
-        }
-
-        const { pageSpeedReport, optimizationPlan } = await response.json();
-        setPageSpeedBefore(pageSpeedReport);
-        setOptimizationPlan(optimizationPlan);
-      } catch (error: any) {
-        setApiError(error.message);
-      } finally {
-        setIsMeasuring(false);
-      }
-      return;
-    }
-
-    // Paid user logic
-    if (!pageSpeedBefore) {
-        setOptimizationPlan(null);
-        setComparisonAnalysis(null);
-        setPageSpeedAfter(null);
-        setCurrentSession({ url, startTime: new Date().toISOString() });
-        setOriginalHtml('');
-        setCleanedHtml('');
-        setImpact(null);
-        setOptions(initialOptions);
-    }
-    
     try {
-        const newReport = await fetchPageSpeedReport(pageSpeedApiKey, url);
+      const idToken = await user?.getIdToken();
+      const response = await fetch('/api/free-measure', {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${idToken}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ urlToScan: url }),
+      });
 
-        if (pageSpeedBefore) {
-            setPageSpeedAfter(newReport);
-            if(currentSession && user) {
-                const endTime = new Date();
-                const duration = (endTime.getTime() - new Date(currentSession.startTime).getTime()) / 1000;
-                
-                const getScore = (report, strategy) => report?.[strategy]?.lighthouseResult?.categories?.performance?.score ?? 0;
+      if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.error || 'Failed to fetch free measurement.');
+      }
 
-                const completedSession: Omit<Session, 'id' | 'userId'> & { userId: string } = {
-                    url: currentSession.url,
-                    startTime: currentSession.startTime,
-                    endTime: endTime.toISOString(),
-                    duration,
-                    beforeScores: {
-                        mobile: getScore(pageSpeedBefore, 'mobile'),
-                        desktop: getScore(pageSpeedBefore, 'desktop'),
-                    },
-                    afterScores: {
-                        mobile: getScore(newReport, 'mobile'),
-                        desktop: getScore(newReport, 'desktop'),
-                    },
-                    userId: user.uid,
-                };
-                
-                const response = await fetch(`/api/sessions?userId=${user.uid}`, {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify(completedSession)
-                });
-                
-                if (!response.ok) {
-                    const errorData = await response.json().catch(() => ({ message: 'The server returned an unexpected error. Check Vercel function logs for details.' }));
-                    throw new Error(errorData.message ? `Could not save session: ${errorData.message}` : 'Could not save session due to a server error.');
-                }
-
-                const savedSession = await response.json();
-                setSessionLog(prevLog => [savedSession, ...prevLog].sort((a, b) => new Date(b.startTime).getTime() - new Date(a.startTime).getTime()));
-                
-                setCurrentSession(null);
-                
-                setIsGeneratingPlan(true);
-                const analysis = await generateComparisonAnalysis(geminiApiKey, pageSpeedBefore, newReport);
-                setComparisonAnalysis(analysis);
-            }
-
-        } else {
-            setPageSpeedBefore(newReport);
-            setIsGeneratingPlan(true);
-            const plan = await generateOptimizationPlan(geminiApiKey, newReport);
-            setOptimizationPlan(plan);
-        }
+      const { pageSpeedReport, optimizationPlan } = await response.json();
+      setPageSpeedBefore(pageSpeedReport);
+      setOptimizationPlan(optimizationPlan);
     } catch (error: any) {
-        console.error("Error during measurement process:", error);
-        let message = error.message;
-        if (message && message.includes('API has not been used')) {
-            message = 'API Error: The PageSpeed Insights API has not been enabled for your key\'s project. Please follow the setup guide to fix this.';
-        }
-        setApiError(message);
-        setCurrentSession(null);
+      setApiError(error.message);
     } finally {
-        setIsMeasuring(false);
-        setIsGeneratingPlan(false);
+      setIsMeasuring(false);
     }
   };
 
@@ -556,30 +404,8 @@ const App = () => {
             <Step number="1" title="Measure Your Page Speed">
                 {currentSession && <SessionTimer startTime={currentSession.startTime} />}
                 <p className="text-sm text-brand-text-secondary mb-3">
-                  { !pageSpeedApiKey ? "You are on a free trial. To unlock all features, please add your own API keys." : "Manage your API keys below, then enter a URL to get a baseline performance report." }
+                  Enter a URL to get a baseline performance report.
                 </p>
-                 <div className="space-y-4 p-4 rounded-lg bg-brand-surface border border-brand-border mb-4">
-                     <ApiKeyInput
-                        label="Gemini API Key"
-                        value={geminiApiKey}
-                        onChange={(e) => setGeminiApiKey(e.target.value)}
-                        isEditing={isEditingGeminiKey}
-                        onEdit={() => setIsEditingGeminiKey(true)}
-                        isSaving={isSaving.gemini}
-                        onSave={() => handleSaveKeys('gemini')}
-                        onDelete={() => handleDeleteKeys('gemini')}
-                     />
-                     <ApiKeyInput
-                        label="PageSpeed API Key"
-                        value={pageSpeedApiKey}
-                        onChange={(e) => setPageSpeedApiKey(e.target.value)}
-                        isEditing={isEditingPageSpeedKey}
-                        onEdit={() => setIsEditingPageSpeedKey(true)}
-                        isSaving={isSaving.pagespeed}
-                        onSave={() => handleSaveKeys('pagespeed')}
-                        onDelete={() => handleDeleteKeys('pagespeed')}
-                     />
-                </div>
                 <div className="flex gap-2">
                     <input type="url" value={url} onChange={e => { setUrl(e.target.value); setPageSpeedBefore(null); }} placeholder="https://your-website.com/your-post" className="flex-grow p-3 bg-brand-background border border-brand-border rounded-lg focus:ring-2 focus:ring-brand-accent-start focus:border-brand-accent-start focus:outline-none text-sm font-mono transition-colors"/>
                     <button onClick={handleMeasure} disabled={isMeasuring || !url || !pageSpeedApiKey || isEditingPageSpeedKey} className="flex items-center justify-center gap-2 w-48 py-3 px-4 bg-gradient-to-r from-brand-accent-start to-brand-accent-end text-white rounded-lg font-semibold transition-all duration-300 transform hover:-translate-y-0.5 disabled:from-brand-surface disabled:to-brand-surface disabled:text-brand-text-secondary disabled:cursor-not-allowed disabled:transform-none">


### PR DESCRIPTION
This commit removes the API key input fields and their related state and functions from the frontend. The application is now configured to always use the free trial logic, with the default API keys being accessed from the backend.