### PR TITLE
feat: Implement free trial limit

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -9,6 +9,7 @@ import Auth from './components/Auth.tsx';
 import VerifyEmail from './components/VerifyEmail.tsx';
 import UserProfile from './components/UserProfile.tsx';
 import { useCleaner } from './hooks/useCleaner.ts';
+import { useUserData } from './hooks/useUserData.ts';
 import { generateOptimizationPlan, generateComparisonAnalysis } from './services/geminiService.ts';
 import { fetchPageSpeedReport } from './services/pageSpeedService.ts';
 import { Recommendation, Session, ImpactSummary } from './types.ts';
@@ -226,6 +227,8 @@ const App = () => {
   const [currentSession, setCurrentSession] = useState<{ url: string; startTime: string; } | null>(null);
   const [sessionLog, setSessionLog] = useState<Session[]>([]);
 
+  const { userData } = useUserData(user);
+
   useEffect(() => {
     const unsubscribe = onAuthStateChanged(auth, (currentUser) => {
         setUser(currentUser);
@@ -404,11 +407,11 @@ const App = () => {
             <Step number="1" title="Measure Your Page Speed">
                 {currentSession && <SessionTimer startTime={currentSession.startTime} />}
                 <p className="text-sm text-brand-text-secondary mb-3">
-                  Enter a URL to get a baseline performance report.
+                  You have {2 - (userData.freeTrialUsage || 0)} free trials remaining.
                 </p>
                 <div className="flex gap-2">
                     <input type="url" value={url} onChange={e => { setUrl(e.target.value); setPageSpeedBefore(null); }} placeholder="https://your-website.com/your-post" className="flex-grow p-3 bg-brand-background border border-brand-border rounded-lg focus:ring-2 focus:ring-brand-accent-start focus:border-brand-accent-start focus:outline-none text-sm font-mono transition-colors"/>
-                    <button onClick={handleMeasure} disabled={isMeasuring || !url || !pageSpeedApiKey || isEditingPageSpeedKey} className="flex items-center justify-center gap-2 w-48 py-3 px-4 bg-gradient-to-r from-brand-accent-start to-brand-accent-end text-white rounded-lg font-semibold transition-all duration-300 transform hover:-translate-y-0.5 disabled:from-brand-surface disabled:to-brand-surface disabled:text-brand-text-secondary disabled:cursor-not-allowed disabled:transform-none">
+                    <button onClick={handleMeasure} disabled={isMeasuring || !url || (userData.freeTrialUsage || 0) >= 2} className="flex items-center justify-center gap-2 w-48 py-3 px-4 bg-gradient-to-r from-brand-accent-start to-brand-accent-end text-white rounded-lg font-semibold transition-all duration-300 transform hover:-translate-y-0.5 disabled:from-brand-surface disabled:to-brand-surface disabled:text-brand-text-secondary disabled:cursor-not-allowed disabled:transform-none">
                       {isMeasuring ? <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-white"></div> : <Icon name="magic" className="w-5 h-5" />}
                       {pageSpeedBefore ? 'Compare Speed' : 'Measure Speed'}
                     </button>

--- a/api/free-measure.ts
+++ b/api/free-measure.ts
@@ -1,5 +1,7 @@
 import { fetchPageSpeedReport } from '../services/pageSpeedService';
 import { generateOptimizationPlan } from '../services/geminiService';
+import { getFirestore, doc, getDoc, setDoc } from 'firebase/firestore';
+import { auth } from '../services/firebase';
 
 export async function POST(request: Request): Promise<Response> {
   const { urlToScan } = await request.json();
@@ -10,9 +12,28 @@ export async function POST(request: Request): Promise<Response> {
     return new Response('Default API keys are not configured.', { status: 500 });
   }
 
+  const idToken = request.headers.get('Authorization')?.split('Bearer ')[1];
+  if (!idToken) {
+    return new Response('Unauthorized', { status: 401 });
+  }
+
   try {
+    const decodedToken = await auth.verifyIdToken(idToken);
+    const userId = decodedToken.uid;
+    const db = getFirestore();
+    const userDocRef = doc(db, 'users', userId);
+    const userDoc = await getDoc(userDocRef);
+    const userData = userDoc.data();
+    const freeTrialUsage = userData?.freeTrialUsage || 0;
+
+    if (freeTrialUsage >= 2) {
+      return new Response('Free trial limit exceeded.', { status: 403 });
+    }
+
     const pageSpeedReport = await fetchPageSpeedReport(pageSpeedApiKey, urlToScan);
     const optimizationPlan = await generateOptimizationPlan(geminiApiKey, pageSpeedReport);
+
+    await setDoc(userDocRef, { freeTrialUsage: freeTrialUsage + 1 }, { merge: true });
 
     return new Response(JSON.stringify({ pageSpeedReport, optimizationPlan }), {
       headers: {

--- a/hooks/useUserData.ts
+++ b/hooks/useUserData.ts
@@ -6,6 +6,7 @@ import { User } from 'firebase/auth';
 interface UserData {
     geminiApiKey?: string;
     pageSpeedApiKey?: string;
+    freeTrialUsage?: number;
 }
 
 export const useUserData = (user: User | null) => {


### PR DESCRIPTION
This commit implements a 2-free-limit for the free trial.

The changes include:
- The `useUserData` hook has been updated to include a `freeTrialUsage` field.
- The `/api/free-measure` endpoint now checks the `freeTrialUsage` field before processing the request.
- The UI has been updated to display the number of free trials remaining and to disable the "Measure Speed" button when you have no free trials left.