### PR TITLE
fix: Correct import path in /api/free-measure

### DIFF
--- a/api/free-measure.ts
+++ b/api/free-measure.ts
@@ -1,7 +1,7 @@
 import { fetchPageSpeedReport } from '../services/pageSpeedService.js';
 import { generateOptimizationPlan } from '../services/geminiService.js';
 import { getFirestore, doc, getDoc, setDoc, collection, addDoc } from 'firebase/firestore';
-import { auth } from '../services/firebase';
+import { auth } from '../services/firebase.js';
 
 export async function POST(request: Request): Promise<Response> {
   try {


### PR DESCRIPTION
This commit corrects the import path for the `firebase` module in the `/api/free-measure` endpoint. This resolves an `ERR_MODULE_NOT_FOUND` error that was causing the function to fail.