### PR TITLE
fix: Use absolute paths in /api/free-measure

### DIFF
--- a/api/free-measure.ts
+++ b/api/free-measure.ts
@@ -1,7 +1,7 @@
-import { fetchPageSpeedReport } from '../services/pageSpeedService.js';
-import { generateOptimizationPlan } from '../services/geminiService.js';
+import { fetchPageSpeedReport } from '/services/pageSpeedService.js';
+import { generateOptimizationPlan } from '/services/geminiService.js';
 import { getFirestore, doc, getDoc, setDoc, collection, addDoc } from 'firebase/firestore';
-import { auth } from '../services/firebase.js';
+import { auth } from '/services/firebase.js';
 
 export async function POST(request: Request): Promise<Response> {
   try {


### PR DESCRIPTION
This commit modifies the `/api/free-measure` endpoint to use absolute paths for imports. This is an attempt to resolve the `ERR_MODULE_NOT_FOUND` error that is occurring in the Vercel serverless function.