### PR TITLE
refactor: Implement path aliases

### DIFF
--- a/api/free-measure.ts
+++ b/api/free-measure.ts
@@ -1,7 +1,7 @@
-import { fetchPageSpeedReport } from '../../services/pageSpeedService.js';
-import { generateOptimizationPlan } from '../../services/geminiService.js';
+import { fetchPageSpeedReport } from '@/services/pageSpeedService.js';
+import { generateOptimizationPlan } from '@/services/geminiService.js';
 import { getFirestore, doc, getDoc, setDoc, collection, addDoc } from 'firebase/firestore';
-import { auth } from '../../services/firebase.js';
+import { auth } from '@/services/firebase.js';
 
 export async function POST(request: Request): Promise<Response> {
   try {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,8 +14,12 @@
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    }
   },
-  "include": ["**/*.ts", "**/*.tsx", "vite-env.d.ts"],
-  "exclude": ["node_modules", "dist"]
+  "include": ["**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,13 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import path from 'path'
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './'),
+    },
+  },
 })


### PR DESCRIPTION
This commit implements path aliases to simplify and robustify module imports.

The changes include:
- The `tsconfig.json` file has been updated to include `baseUrl` and `paths` properties.
- The `vite.config.ts` file has been updated to resolve the path aliases.
- The imports in `api/free-measure.ts` have been updated to use the new path aliases.