### PR TITLE
fix: Remove nodeVersion from vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "functions": {
     "api/**/*.ts": {
-      "runtime": "@vercel/node"
+      "runtime": "@vercel/node@20.x"
     }
   },
   "rewrites": [

--- a/vercel.json
+++ b/vercel.json
@@ -1,9 +1,4 @@
 {
-  "functions": {
-    "api/**/*.ts": {
-      "runtime": "@vercel/node@20.x"
-    }
-  },
   "rewrites": [
     {
       "source": "/api/(.*)",
@@ -12,5 +7,6 @@
   ],
   "buildCommand": "npm run build",
   "outputDirectory": "dist",
-  "framework": "vite"
+  "framework": "vite",
+  "nodeVersion": "20.x"
 }

--- a/vercel.json
+++ b/vercel.json
@@ -12,6 +12,5 @@
   ],
   "buildCommand": "npm run build",
   "outputDirectory": "dist",
-  "framework": "vite",
-  "nodeVersion": "20.x"
+  "framework": "vite"
 }


### PR DESCRIPTION
This commit removes the `nodeVersion` property from the `vercel.json` file. This property is not a valid part of the `vercel.json` schema and was causing the build to fail.