### PR TITLE
fix: Correctly compare before and after PageSpeed reports

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -367,7 +367,7 @@ const MainApp = ({ sessionLog, setSessionLog }: MainAppProps) => {
 
     try {
         const idToken = await user.getIdToken();
-        const response = await fetch('/api/free-measure', {
+        const response = await fetch('/api/fetch-report', {
             method: 'POST',
             headers: {
                 'Authorization': `Bearer ${idToken}`,

--- a/api/fetch-report.ts
+++ b/api/fetch-report.ts
@@ -1,0 +1,68 @@
+import { auth } from '../services/firebase-admin.js';
+import { fetchPageSpeedReport } from '../services/pageSpeedService.js';
+
+export async function POST(request: Request): Promise<Response> {
+  try {
+    if (!auth) {
+        return new Response(JSON.stringify({ error: 'Server configuration error: Firebase not initialized.' }), {
+            status: 500, headers: { 'Content-Type': 'application/json' }
+        });
+    }
+
+    let requestBody;
+    try {
+      requestBody = await request.json();
+    } catch (parseError) {
+      return new Response(JSON.stringify({ error: 'Invalid JSON in request body.' }), {
+        status: 400, headers: { 'Content-Type': 'application/json' }
+      });
+    }
+
+    const { urlToScan } = requestBody;
+    if (!urlToScan) {
+      return new Response(JSON.stringify({ error: 'URL to scan is required.' }), {
+        status: 400, headers: { 'Content-Type': 'application/json' }
+      });
+    }
+
+    const authHeader = request.headers.get('Authorization');
+    const idToken = authHeader?.split('Bearer ')[1];
+    if (!idToken) {
+      return new Response(JSON.stringify({ error: 'Unauthorized: No token provided.' }), {
+        status: 401, headers: { 'Content-Type': 'application/json' }
+      });
+    }
+
+    try {
+      await auth.verifyIdToken(idToken);
+    } catch (authError) {
+      return new Response(JSON.stringify({ error: 'Invalid authentication token.' }), {
+        status: 401, headers: { 'Content-Type': 'application/json' }
+      });
+    }
+
+    const pageSpeedApiKey = process.env.DEFAULT_PAGESPEED_API_KEY;
+    if (!pageSpeedApiKey) {
+      return new Response(JSON.stringify({ error: 'Server configuration error: PageSpeed API key not set.' }), {
+        status: 500, headers: { 'Content-Type': 'application/json' }
+      });
+    }
+
+    const pageSpeedReport = await fetchPageSpeedReport(pageSpeedApiKey, urlToScan);
+
+    return new Response(JSON.stringify({ pageSpeedReport }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+  } catch (error: any) {
+    const errorMessage = error instanceof Error ? error.message : 'An unknown error occurred.';
+    return new Response(JSON.stringify({
+      error: 'An unexpected server error occurred.',
+      details: errorMessage,
+    }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+}


### PR DESCRIPTION
The application was previously calling the wrong API endpoint for comparison, which caused a new session to be created instead of just fetching a new report. This resulted in incorrect behavior and wasted free trial credits.

This commit fixes the issue by:
- Creating a new, dedicated API endpoint `/api/fetch-report` that only fetches a PageSpeed report without any side effects.
- Updating the `handleCompare` function to use this new endpoint.
- This ensures that the comparison logic is correct and the application behaves as expected.