### PR TITLE
fix: Prevent session log overwriting and implement 30-day retention

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -219,6 +219,7 @@ const MainApp = ({ sessionLog, setSessionLog }: MainAppProps) => {
   const [isGeneratingPlan, ] = useState(false);
   const [apiError, setApiError] = useState('');
   const [sessionLoadError, setSessionLoadError] = useState('');
+  const [sessionNotification, setSessionNotification] = useState<string | null>(null);
 
   const [originalHtml, setOriginalHtml] = useState('');
   const [cleanedHtml, setCleanedHtml] = useState('');
@@ -275,8 +276,11 @@ const MainApp = ({ sessionLog, setSessionLog }: MainAppProps) => {
                 const errorData = await sessionsResponse.json().catch(() => ({ message: 'Failed to fetch session data.' }));
                 throw new Error(errorData.message);
             }
-            const sessionsData = await sessionsResponse.json();
-            setSessionLog(sessionsData);
+            const { sessions, notification } = await sessionsResponse.json();
+            setSessionLog(sessions);
+            if (notification) {
+                setSessionNotification(notification);
+            }
         } catch (error: any) {
             console.error("Failed to load user data:", error);
             setSessionLoadError(`Could not load history or keys: ${error.message}`);
@@ -510,6 +514,11 @@ const MainApp = ({ sessionLog, setSessionLog }: MainAppProps) => {
               <SetupGuide />
             </div>
             <div className="mb-2">
+              {sessionNotification && (
+                <div className="mb-4 p-3 bg-brand-warning/10 border border-brand-warning/30 rounded-lg text-sm text-brand-warning">
+                  {sessionNotification}
+                </div>
+              )}
               <SessionLog sessions={sessionLog} setSessions={setSessionLog} userId={user.uid} />
               {sessionLoadError && <p className="mt-2 text-sm text-brand-danger p-3 bg-brand-danger/10 border border-brand-danger/30 rounded-lg">{sessionLoadError}</p>}
             </div>

--- a/api/sessions.ts
+++ b/api/sessions.ts
@@ -2,6 +2,7 @@ import { put, list, del } from '@vercel/blob';
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import type { Session } from '../types';
 
+const THIRTY_DAYS_IN_MS = 30 * 24 * 60 * 60 * 1000;
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
     const { method } = req;
@@ -15,53 +16,58 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         return res.status(500).json({ message: 'Storage token is not configured.' });
     }
     
-    const blobPath = `sessions/${userId}.json`;
+    const userSessionPath = `sessions/${userId}/`;
 
     try {
         if (method === 'GET') {
-            const { blobs } = await list({ prefix: blobPath, limit: 1, token: process.env.BLOB_READ_WRITE_TOKEN });
-            if (blobs.length === 0) {
-                return res.status(200).json([]);
-            }
+            const { blobs } = await list({ prefix: userSessionPath, token: process.env.BLOB_READ_WRITE_TOKEN });
             
-            try {
-                const response = await fetch(blobs[0].url);
-                if (!response.ok) throw new Error(`Fetch failed with status ${response.status}`);
-                if (response.headers.get('content-length') === '0') {
-                     return res.status(200).json([]);
+            const sessions: Session[] = [];
+            const blobsToDelete: string[] = [];
+            let hasOldLogs = false;
+
+            for (const blob of blobs) {
+                try {
+                    const response = await fetch(blob.url);
+                    if (!response.ok) continue;
+                    const session = await response.json() as Session;
+
+                    const sessionAge = Date.now() - new Date(session.startTime).getTime();
+                    if (sessionAge > THIRTY_DAYS_IN_MS) {
+                        blobsToDelete.push(blob.url);
+                        hasOldLogs = true;
+                        continue;
+                    }
+                    sessions.push(session);
+                } catch (e) {
+                    console.error(`Failed to parse session data for blob ${blob.pathname}, scheduling for deletion.`, e);
+                    blobsToDelete.push(blob.url);
                 }
-                const data = await response.json();
-                return res.status(200).json(data);
-            } catch (e) {
-                console.error(`Failed to read or parse session data for user ${userId}:`, e);
-                return res.status(200).json([]);
             }
+
+            if (blobsToDelete.length > 0) {
+                console.log(`Deleting ${blobsToDelete.length} old or invalid session logs for user ${userId}.`);
+                await del(blobsToDelete, { token: process.env.BLOB_READ_WRITE_TOKEN });
+            }
+
+            const sortedSessions = sessions.sort((a, b) => new Date(b.startTime).getTime() - new Date(a.startTime).getTime());
+
+            const responsePayload = {
+                sessions: sortedSessions,
+                notification: hasOldLogs ? `Some of your session logs older than 30 days have been automatically deleted. Please download your logs regularly.` : null
+            };
+
+            return res.status(200).json(responsePayload);
         }
 
         if (method === 'POST') {
             const newSession: Omit<Session, 'id'> = req.body;
+            const sessionId = new Date().toISOString();
+            const sessionWithId: Session = { ...newSession, id: sessionId };
             
-            let sessions: Session[] = [];
-            const { blobs } = await list({ prefix: blobPath, limit: 1, token: process.env.BLOB_READ_WRITE_TOKEN });
-            if (blobs.length > 0) {
-                try {
-                    const response = await fetch(blobs[0].url);
-                    if (response.ok && response.headers.get('content-length') !== '0') {
-                       const existingData = await response.json();
-                       if (Array.isArray(existingData)) {
-                          sessions = existingData;
-                       }
-                    }
-                } catch (e) { 
-                    console.error("Could not parse existing session data, starting new log.", e);
-                }
-            }
-            
-            const sessionWithId: Session = { ...newSession, id: new Date().toISOString() };
-            const updatedSessions = [sessionWithId, ...sessions]
-                .sort((a, b) => new Date(b.startTime).getTime() - new Date(a.startTime).getTime());
+            const blobPath = `${userSessionPath}${sessionId}.json`;
 
-            await put(blobPath, JSON.stringify(updatedSessions), {
+            await put(blobPath, JSON.stringify(sessionWithId), {
                 access: 'public',
                 addRandomSuffix: false,
                 token: process.env.BLOB_READ_WRITE_TOKEN,
@@ -71,9 +77,9 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         }
         
         if (method === 'DELETE') {
-            const { blobs } = await list({ prefix: blobPath, limit: 1, token: process.env.BLOB_READ_WRITE_TOKEN });
-            if(blobs.length > 0) {
-               await del(blobs[0].url, { token: process.env.BLOB_READ_WRITE_TOKEN });
+            const { blobs } = await list({ prefix: userSessionPath, token: process.env.BLOB_READ_WRITE_TOKEN });
+            if (blobs.length > 0) {
+                await del(blobs.map(b => b.url), { token: process.env.BLOB_READ_WRITE_TOKEN });
             }
             return res.status(200).json({ success: true, message: 'History cleared.' });
         }


### PR DESCRIPTION
The previous implementation stored all user sessions in a single JSON blob, which led to overwriting issues and was not scalable. This commit refactors the session storage logic to address this.

- Each session is now stored as a separate blob, preventing overwrites and improving performance.
- The `GET /api/sessions` endpoint now fetches all session blobs for a user and combines them.
- A 30-day retention policy is implemented directly in the `GET` handler, which deletes sessions older than 30 days.
- The frontend is updated to handle the new API response, including displaying a notification to you about deleted logs.