### PR TITLE
I've fixed an issue where the application was not clearing the 'Origi…

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -302,6 +302,9 @@ const MainApp = ({ sessionLog, setSessionLog }: MainAppProps) => {
     setApiError('');
     setSessionLoadError('');
     setPageSpeedAfter(null);
+    setOriginalHtml('');
+    setCleanedHtml('');
+    setImpact(null);
     setSessionStartTime(Date.now());
 
     try {


### PR DESCRIPTION
…nal HTML', 'Cleaned HTML', and 'Impact' fields when you entered and measured a new URL. This was causing old data to be displayed for new sessions.

I addressed this by resetting the `originalHtml`, `cleanedHtml`, and `impact` state variables in the `handleMeasure` function.