### PR TITLE
feat: Update session log and detailed view

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -405,7 +405,16 @@ const MainApp = ({ sessionLog, setSessionLog }: MainAppProps) => {
         if (sessionStartTime) {
             const sessionEndTime = Date.now();
 
-            const getScore = (report: any, strategy: 'mobile' | 'desktop') => report?.[strategy]?.lighthouseResult?.categories?.performance?.score ?? 0;
+            const getScores = (report: any, strategy: 'mobile' | 'desktop') => {
+                const categories = report?.[strategy]?.lighthouseResult?.categories;
+                return {
+                    mobile: categories?.performance?.score ?? 0,
+                    desktop: categories?.performance?.score ?? 0,
+                    accessibility: categories?.accessibility?.score ?? 0,
+                    bestPractices: categories?.['best-practices']?.score ?? 0,
+                    seo: categories?.seo?.score ?? 0,
+                };
+            };
 
             const newSession: Session = {
                 id: new Date().toISOString(),
@@ -414,14 +423,8 @@ const MainApp = ({ sessionLog, setSessionLog }: MainAppProps) => {
                 endTime: new Date(sessionEndTime).toISOString(),
                 duration: sessionDuration,
                 report: afterReport,
-                beforeScores: {
-                    mobile: getScore(pageSpeedBefore, 'mobile'),
-                    desktop: getScore(pageSpeedBefore, 'desktop'),
-                },
-                afterScores: {
-                    mobile: getScore(afterReport, 'mobile'),
-                    desktop: getScore(afterReport, 'desktop'),
-                },
+                beforeScores: getScores(pageSpeedBefore, 'mobile'),
+                afterScores: getScores(afterReport, 'mobile'),
                 userId: user.uid,
             };
 

--- a/components/DetailedLogPage.tsx
+++ b/components/DetailedLogPage.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useMemo } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { Session } from '../types';
 import { getDhakaDate, formatDuration } from '../utils/time';
 import Icon from './Icon';
@@ -44,6 +45,7 @@ const convertToCSV = (sessions: Session[]): string => {
 };
 
 const DetailedLogPage: React.FC<DetailedLogPageProps> = ({ sessions }) => {
+  const navigate = useNavigate();
   const [filter, setFilter] = useState<'day' | 'week' | 'month' | 'year'>('day');
 
   const filteredSessions = useMemo(() => {
@@ -91,20 +93,27 @@ const DetailedLogPage: React.FC<DetailedLogPageProps> = ({ sessions }) => {
           <button onClick={() => setFilter('month')} className={`px-4 py-2 rounded ${filter === 'month' ? 'bg-brand-accent-start text-white' : 'bg-brand-surface'}`}>Month</button>
           <button onClick={() => setFilter('year')} className={`px-4 py-2 rounded ${filter === 'year' ? 'bg-brand-accent-start text-white' : 'bg-brand-surface'}`}>Year</button>
         </div>
-        <button onClick={handleDownload} className="flex items-center gap-2 text-sm font-semibold py-2 px-4 bg-brand-surface border border-brand-border hover:bg-brand-border rounded-md transition-colors">
-          <Icon name="sheet" className="w-4 h-4" /> Download CSV
-        </button>
+        <div className="flex items-center gap-x-2">
+            <button onClick={handleDownload} className="flex items-center gap-2 text-sm font-semibold py-2 px-4 bg-brand-surface border border-brand-border hover:bg-brand-border rounded-md transition-colors">
+            <Icon name="sheet" className="w-4 h-4" /> Download CSV
+            </button>
+            <button onClick={() => navigate('/')} className="flex items-center gap-2 text-sm font-semibold py-2 px-4 bg-brand-surface border border-brand-border hover:bg-brand-border rounded-md transition-colors">
+                <Icon name="close" className="w-4 h-4" /> Close
+            </button>
+        </div>
       </div>
 
       <div className="overflow-x-auto">
         <table className="w-full min-w-[600px] text-left">
           <thead>
             <tr className="border-b border-brand-border text-xs text-brand-text-secondary uppercase">
-              <th className="py-2 pr-2 font-semibold">Date (Dhaka)</th>
+              <th className="py-2 pr-2 font-semibold">Date</th>
               <th className="py-2 px-2 font-semibold">URL</th>
               <th className="py-2 px-2 font-semibold">Duration</th>
-              <th className="py-2 pl-2 font-semibold">Mobile Perf.</th>
-              <th className="py-2 pl-2 font-semibold">Desktop Perf.</th>
+              <th className="py-2 pl-2 font-semibold">Performance</th>
+              <th className="py-2 pl-2 font-semibold">Accessibility</th>
+              <th className="py-2 pl-2 font-semibold">Best Practices</th>
+              <th className="py-2 pl-2 font-semibold">SEO</th>
             </tr>
           </thead>
           <tbody>
@@ -114,7 +123,9 @@ const DetailedLogPage: React.FC<DetailedLogPageProps> = ({ sessions }) => {
                 <td className="py-3 px-2 truncate max-w-xs text-brand-accent-start" title={session.url}>{session.url}</td>
                 <td className="py-3 px-2 font-mono">{formatDuration(session.duration)}</td>
                 <td className="py-3 pl-2"><ScoreDiff before={session.beforeScores.mobile} after={session.afterScores.mobile} /></td>
-                <td className="py-3 pl-2"><ScoreDiff before={session.beforeScores.desktop} after={session.afterScores.desktop} /></td>
+                <td className="py-3 pl-2"><ScoreDiff before={session.beforeScores.accessibility} after={session.afterScores.accessibility} /></td>
+                <td className="py-3 pl-2"><ScoreDiff before={session.beforeScores.bestPractices} after={session.afterScores.bestPractices} /></td>
+                <td className="py-3 pl-2"><ScoreDiff before={session.beforeScores.seo} after={session.afterScores.seo} /></td>
               </tr>
             ))}
           </tbody>

--- a/components/SessionLog.tsx
+++ b/components/SessionLog.tsx
@@ -1,7 +1,7 @@
 import { useState, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import Icon from './Icon';
-import { getDhakaDate, formatDuration, isToday } from '../utils/time';
+import { getDhakaDate, formatDuration } from '../utils/time';
 import { Session } from '../types';
 
 interface SessionLogProps {
@@ -55,11 +55,10 @@ const SessionLog = ({ sessions, setSessions, userId }: SessionLogProps) => {
     const navigate = useNavigate();
     const [isOpen, setIsOpen] = useState(true);
     const [isClearing, setIsClearing] = useState(false);
-    const [showAll, setShowAll] = useState(false);
 
     const displayedSessions = useMemo(() => {
-        return showAll ? sessions : sessions.slice(0, 3);
-    }, [sessions, showAll]);
+        return sessions.slice(0, 3);
+    }, [sessions]);
 
     const handleDownload = () => {
         const csv = convertToCSV(sessions);
@@ -114,7 +113,7 @@ const SessionLog = ({ sessions, setSessions, userId }: SessionLogProps) => {
                             <div>
                                 <h4 className="font-semibold text-brand-text-primary">Your Session Log</h4>
                                 <p className="text-xs text-brand-text-secondary mt-1">
-                                    {showAll ? `Showing all ${sessions.length} sessions.` : `Showing ${todaySessions.length} of ${sessions.length} total sessions from today.`}
+                                    {`Showing the latest ${displayedSessions.length} of ${sessions.length} total sessions.`}
                                 </p>
                             </div>
                            <div className="flex gap-2 flex-wrap">

--- a/components/SessionLog.tsx
+++ b/components/SessionLog.tsx
@@ -57,11 +57,9 @@ const SessionLog = ({ sessions, setSessions, userId }: SessionLogProps) => {
     const [isClearing, setIsClearing] = useState(false);
     const [showAll, setShowAll] = useState(false);
 
-    const todaySessions = useMemo(() => {
-        return sessions.filter(s => isToday(new Date(s.startTime)));
-    }, [sessions]);
-
-    const displayedSessions = showAll ? sessions : todaySessions;
+    const displayedSessions = useMemo(() => {
+        return showAll ? sessions : sessions.slice(0, 3);
+    }, [sessions, showAll]);
 
     const handleDownload = () => {
         const csv = convertToCSV(sessions);
@@ -120,12 +118,12 @@ const SessionLog = ({ sessions, setSessions, userId }: SessionLogProps) => {
                                 </p>
                             </div>
                            <div className="flex gap-2 flex-wrap">
-                             {sessions.length > todaySessions.length && (
+                             {sessions.length > 3 && (
                                 <button
-                                    onClick={() => setShowAll(!showAll)}
+                                    onClick={() => navigate('/logs')}
                                     className="text-sm font-semibold py-2 px-4 bg-brand-surface border border-brand-border hover:bg-brand-border rounded-md transition-colors"
                                 >
-                                    {showAll ? 'Show Today' : `Show All History (${sessions.length})`}
+                                    View Detailed Log
                                 </button>
                              )}
                               <button onClick={handleDownload} className="flex items-center gap-2 text-sm font-semibold py-2 px-4 bg-brand-surface border border-brand-border hover:bg-brand-border rounded-md transition-colors">
@@ -144,11 +142,13 @@ const SessionLog = ({ sessions, setSessions, userId }: SessionLogProps) => {
                                 <table className="w-full min-w-[600px] text-left">
                                     <thead>
                                         <tr className="border-b border-brand-border text-xs text-brand-text-secondary uppercase">
-                                            <th className="py-2 pr-2 font-semibold">Date (Dhaka)</th>
+                                            <th className="py-2 pr-2 font-semibold">Date</th>
                                             <th className="py-2 px-2 font-semibold">URL</th>
                                             <th className="py-2 px-2 font-semibold">Duration</th>
-                                            <th className="py-2 pl-2 font-semibold">Mobile Perf.</th>
-                                            <th className="py-2 pl-2 font-semibold">Desktop Perf.</th>
+                                            <th className="py-2 pl-2 font-semibold">Performance</th>
+                                            <th className="py-2 pl-2 font-semibold">Accessibility</th>
+                                            <th className="py-2 pl-2 font-semibold">Best Practices</th>
+                                            <th className="py-2 pl-2 font-semibold">SEO</th>
                                         </tr>
                                     </thead>
                                     <tbody>
@@ -158,7 +158,9 @@ const SessionLog = ({ sessions, setSessions, userId }: SessionLogProps) => {
                                                 <td className="py-3 px-2 truncate max-w-xs text-brand-accent-start" title={session.url}>{session.url}</td>
                                                 <td className="py-3 px-2 font-mono">{formatDuration(session.duration)}</td>
                                                 <td className="py-3 pl-2"><ScoreDiff before={session.beforeScores.mobile} after={session.afterScores.mobile} /></td>
-                                                <td className="py-3 pl-2"><ScoreDiff before={session.beforeScores.desktop} after={session.afterScores.desktop} /></td>
+                                                <td className="py-3 pl-2"><ScoreDiff before={session.beforeScores.accessibility} after={session.afterScores.accessibility} /></td>
+                                                <td className="py-3 pl-2"><ScoreDiff before={session.beforeScores.bestPractices} after={session.afterScores.bestPractices} /></td>
+                                                <td className="py-3 pl-2"><ScoreDiff before={session.beforeScores.seo} after={session.afterScores.seo} /></td>
                                             </tr>
                                         ))}
                                     </tbody>

--- a/types.ts
+++ b/types.ts
@@ -27,8 +27,8 @@ export interface Session {
   endTime: string;
   duration: number;
   report: { mobile: PageSpeedReport, desktop: PageSpeedReport };
-  beforeScores: { mobile: number, desktop: number };
-  afterScores: { mobile: number, desktop: number };
+  beforeScores: { mobile: number, desktop: number, accessibility: number, bestPractices: number, seo: number };
+  afterScores: { mobile: number, desktop: number, accessibility: number, bestPractices: number, seo: number };
   userId: string;
   comparisonAnalysis?: any;
 }


### PR DESCRIPTION
This commit implements several requested changes to the session log and detailed view:

- The session log now displays all four performance scores (Performance, Accessibility, Best Practices, and SEO).
- The session log now defaults to showing only the three latest entries, with a 'View Detailed Log' button to see the full history.
- The detailed log page now also displays all four performance scores.
- A close button has been added to the detailed log page to allow you to easily exit the view.