### PR TITLE
Feat: Enhance image lazy loading with IntersectionObserver and <picture>

### DIFF
--- a/hooks/useCleaner.ts
+++ b/hooks/useCleaner.ts
@@ -221,6 +221,50 @@ const lazyLoadBackgroundImages = (doc: Document): number => {
 
 const lazyLoadScript = `<script id="fastload-lazy-loader">(function(){"use strict";if(window.fastloadLazyLoaderInitialized)return;window.fastloadLazyLoaderInitialized=!0;function e(e,t,c){const d=document.getElementById(e);if(d)return void(c&&c());const n=document.createElement("script");n.id=e,n.src=t,n.async=!0,c&&(n.onload=c),document.head.appendChild(n)}function addHoverEffects(){document.querySelectorAll(".lazy-youtube-facade").forEach(e=>{const t=e.querySelector(".play-icon-wrapper");e.addEventListener("mouseenter",()=>{e.style.transform="scale(1.02)",e.style.boxShadow="0 10px 30px rgba(255,0,0,0.2)",t&&(t.style.transform="scale(1.1)",t.style.background="rgba(22,27,34,0.7)")}),e.addEventListener("mouseleave",()=>{e.style.transform="scale(1)",e.style.boxShadow="none",t&&(t.style.transform="scale(1)",t.style.background="rgba(22,27,34,0.5)")})}),document.querySelectorAll(".lazy-tweet-facade").forEach(e=>{const t=e.querySelector(".load-button");e.addEventListener("mouseenter",()=>{e.style.borderColor="#38BDF8",e.style.transform="translateY(-2px)",e.style.boxShadow="0 8px 25px rgba(56,189,248,0.15)",t&&(t.style.backgroundColor="#fff")}),e.addEventListener("mouseleave",()=>{e.style.borderColor="#30363D",e.style.transform="translateY(0)",e.style.boxShadow="none",t&&(t.style.backgroundColor="#E6EDF3")})}),document.querySelectorAll(".lazy-instagram-facade").forEach(e=>{const t=e.querySelector(".insta-gradient-border");e.addEventListener("mouseenter",()=>{e.style.transform="scale(1.03)",e.style.boxShadow="0 10px 30px rgba(220,39,67,0.2)",t&&(t.style.transform="rotate(180deg)")}),e.addEventListener("mouseleave",()=>{e.style.transform="scale(1)",e.style.boxShadow="none",t&&(t.style.transform="rotate(0deg)")})}),document.querySelectorAll(".lazy-tiktok-facade").forEach(e=>{const t=e.querySelector(".tiktok-glow"),c=e.querySelector(".load-button");e.addEventListener("mouseenter",()=>{e.style.borderColor="#fe2c55",e.style.transform="translateY(-3px)",e.style.boxShadow="0 10px 30px rgba(254,44,85,0.2)",t&&(t.style.opacity="1"),c&&(c.style.transform="scale(1.05)")}),e.addEventListener("mouseleave",()=>{e.style.borderColor="#30363D",e.style.transform="translateY(0)",e.style.boxShadow="none",t&&(t.style.opacity="0"),c&&(c.style.transform="scale(1)")})}),document.querySelectorAll(".lazy-reddit-facade").forEach(e=>{e.addEventListener("mouseenter",()=>{e.style.borderColor="#FF4500",e.style.transform="translateY(-2px)",e.style.boxShadow="0 8px 25px rgba(255,69,0,0.15)"}),e.addEventListener("mouseleave",()=>{e.style.borderColor="#30363D",e.style.transform="translateY(0)",e.style.boxShadow="none"})})}function t(t){if(t.matches(".lazy-youtube-facade")){const videoId=t.getAttribute("data-video-id"),originalSrc=t.getAttribute("data-original-src");if(!videoId||!originalSrc)return;const d=document.createElement("iframe"),n=new URL(originalSrc.startsWith("//")?"https:"+originalSrc:originalSrc);n.searchParams.set("autoplay","1"),n.searchParams.set("rel","0"),d.setAttribute("src",n.toString()),d.setAttribute("frameborder","0"),d.setAttribute("allow","accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"),d.setAttribute("allowfullscreen",""),d.style.cssText="position:absolute;top:0;left:0;width:100%;height:100%;border:0;border-radius:12px;";const wrapper=document.createElement("div");wrapper.style.cssText="position:relative;width:100%;max-width:"+t.style.maxWidth+";aspect-ratio:"+t.style.aspectRatio+";margin:1rem auto;",wrapper.appendChild(d),t.parentNode?.replaceChild(wrapper,t);return}const c=t.parentNode;if(!c)return;let d,n,o,r,a;if(t.matches(".lazy-tweet-facade"))d="tweet",n="data-tweet-html",o="twitter-wjs",r="https://platform.twitter.com/widgets.js",a=()=>window.twttr&&window.twttr.widgets&&window.twttr.widgets.load(c);else if(t.matches(".lazy-instagram-facade"))d="instagram",n="data-insta-html",o="instagram-embed-script",r="https://www.instagram.com/embed.js",a=()=>window.instgrm&&window.instgrm.Embeds.process();else if(t.matches(".lazy-tiktok-facade"))d="tiktok",n="data-tiktok-html",o="tiktok-embed-script",r="https://www.tiktok.com/embed.js",a=null;else if(t.matches(".lazy-reddit-facade"))d="reddit",n="data-reddit-html",o="reddit-widgets-js",r="https://embed.reddit.com/widgets.js",a=null;else return;if(!d)return;const i=t.getAttribute(n);if(!i)return;try{const s=decodeURIComponent(escape(window.atob(i))),l=document.createElement("div");l.innerHTML=s;const m=l.firstChild;m&&(c.replaceChild(m,t),r&&e(o,r,a))}catch(error){console.error("Error loading social media embed:",error)}}document.addEventListener("click",function(e){const target=e.target.closest(".lazy-youtube-facade, .lazy-tweet-facade, .lazy-instagram-facade, .lazy-tiktok-facade, .lazy-reddit-facade");target&&t(target)}),document.addEventListener("DOMContentLoaded",addHoverEffects),addHoverEffects()})();</script>`;
 
+const imageIntersectionObserverScript = `<script id="fastload-image-lazy-loader">
+(function() {
+  'use strict';
+  document.addEventListener("DOMContentLoaded", function() {
+    const lazyImages = Array.from(document.querySelectorAll('img.lazy-image'));
+
+    if (!('IntersectionObserver' in window)) {
+      lazyImages.forEach(img => loadImg(img));
+      return;
+    }
+
+    const observer = new IntersectionObserver((entries, observer) => {
+      entries.forEach(entry => {
+        if (entry.isIntersecting) {
+          const img = entry.target;
+          loadImg(img);
+          observer.unobserve(img);
+        }
+      });
+    }, { rootMargin: '200px' });
+
+    lazyImages.forEach(img => observer.observe(img));
+
+    function loadImg(img) {
+      const picture = img.parentElement;
+      if (picture && picture.tagName === 'PICTURE') {
+        const sources = picture.querySelectorAll('source[data-srcset]');
+        sources.forEach(source => {
+          source.srcset = source.dataset.srcset;
+          source.removeAttribute('data-srcset');
+        });
+      }
+      if (img.dataset.src) {
+        img.src = img.dataset.src;
+        img.removeAttribute('data-src');
+      }
+      img.classList.add('loaded');
+      img.style.filter = 'none';
+      img.style.opacity = '1';
+    }
+  });
+})();
+</script>`;
+
 const optimizeSvgs = (doc: Document): number => {
     let svgsOptimized = 0;
     doc.querySelectorAll('svg').forEach(svg => {
@@ -242,16 +286,17 @@ const optimizeSvgs = (doc: Document): number => {
     return svgsOptimized;
 };
 
-const addResponsiveSrcset = (doc: Document): { imagesWithSrcset: number, dimensionsAdded: number } => {
+const addResponsiveSrcset = (doc: Document, options: CleaningOptions): { imagesWithSrcset: number, dimensionsAdded: number } => {
     let imagesWithSrcset = 0;
     let dimensionsAdded = 0;
     const cdnHosts = ['i0.wp.com', 'i1.wp.com', 'i2.wp.com', 'i3.wp.com', 'cloudinary.com', 'imgix.net'];
     const breakpoints = [320, 480, 640, 768, 1024, 1280, 1536];
 
     doc.querySelectorAll('img').forEach(img => {
-        if (img.hasAttribute('srcset')) return;
+        if (img.closest('picture')) return; // Already wrapped in a picture element.
+
         const src = img.getAttribute('src');
-        if (!src) return;
+        if (!src || src.startsWith('data:')) return;
 
         try {
             const url = new URL(src);
@@ -266,13 +311,18 @@ const addResponsiveSrcset = (doc: Document): { imagesWithSrcset: number, dimensi
                 }
                 return;
             }
-            if (url.hostname.includes('wp.com')) {
-                const existingWidthParam = url.searchParams.get('w');
-                const imageWidthAttr = img.getAttribute('width');
-                let originalWidth: number | null = null;
-                if (existingWidthParam) originalWidth = parseInt(existingWidthParam, 10);
-                else if (imageWidthAttr) originalWidth = parseInt(imageWidthAttr, 10);
-                if (!originalWidth) return;
+
+            const imageWidthAttr = img.getAttribute('width');
+            const existingWidthParam = url.searchParams.get('w');
+            let originalWidth: number | null = null;
+            if (imageWidthAttr) originalWidth = parseInt(imageWidthAttr, 10);
+            else if (existingWidthParam) originalWidth = parseInt(existingWidthParam, 10);
+
+            if (!originalWidth) return;
+
+            const picture = doc.createElement('picture');
+
+            const createSrcset = (format: string | null) => {
                 const srcset: string[] = [];
                 breakpoints.forEach(w => {
                     if (w <= originalWidth!) {
@@ -280,16 +330,55 @@ const addResponsiveSrcset = (doc: Document): { imagesWithSrcset: number, dimensi
                         newUrl.searchParams.set('w', w.toString());
                         newUrl.searchParams.delete('h');
                         newUrl.searchParams.delete('fit');
+                        if (format) {
+                            newUrl.searchParams.set('format', format);
+                        }
                         srcset.push(`${newUrl.toString()} ${w}w`);
                     }
                 });
-                if (srcset.length > 0) {
-                    img.setAttribute('srcset', srcset.join(', '));
-                    img.setAttribute('sizes', `(max-width: ${originalWidth}px) 100vw, ${originalWidth}px`);
-                    imagesWithSrcset++;
+                return srcset.join(', ');
+            };
+
+            const targetFormat = options.convertToAvif ? 'avif' : (options.optimizeImages ? 'webp' : null);
+
+            if (targetFormat) {
+                const source = doc.createElement('source');
+                source.type = `image/${targetFormat}`;
+                const srcset = createSrcset(targetFormat);
+                if (options.progressiveImageLoading && img.classList.contains('lazy-image')) {
+                    source.setAttribute('data-srcset', srcset);
+                } else {
+                    source.setAttribute('srcset', srcset);
                 }
+                picture.appendChild(source);
             }
-        } catch (e) { /* ignore invalid urls */ }
+
+            const originalFormatMatch = src.match(/\.(jpe?g|png|gif)/i);
+            const originalFormat = originalFormatMatch ? (originalFormatMatch[1].toLowerCase().replace('jpg', 'jpeg')) : null;
+
+            if (originalFormat && targetFormat !== originalFormat) {
+                 const source = doc.createElement('source');
+                 source.type = `image/${originalFormat}`;
+                 const srcset = createSrcset(null); // original format
+                 if (options.progressiveImageLoading && img.classList.contains('lazy-image')) {
+                     source.setAttribute('data-srcset', srcset);
+                 } else {
+                     source.setAttribute('srcset', srcset);
+                 }
+                 picture.appendChild(source);
+            }
+
+            const newImg = img.cloneNode(true) as HTMLImageElement;
+            picture.appendChild(newImg);
+
+            if (img.parentNode) {
+                img.parentNode.replaceChild(picture, img);
+                imagesWithSrcset++;
+            }
+
+        } catch (e) {
+            console.error("Error processing image for responsive srcset:", e);
+        }
     });
     return { imagesWithSrcset, dimensionsAdded };
 };
@@ -424,59 +513,19 @@ export const useCleaner = () => {
 
         lazyElementsFound = !!doc.querySelector('.lazy-image, .lazy-bg, .lazy-video-facade, .lazy-youtube-facade, .lazy-tweet-facade, .lazy-instagram-facade, .lazy-tiktok-facade, .lazy-reddit-facade');
 
-        if (effectiveOptions.addResponsiveSrcset) {
-            const { imagesWithSrcset, dimensionsAdded } = addResponsiveSrcset(doc);
+        if (effectiveOptions.addResponsiveSrcset || effectiveOptions.optimizeImages) {
+            const { imagesWithSrcset, dimensionsAdded } = addResponsiveSrcset(doc, effectiveOptions);
             if (imagesWithSrcset > 0) {
-                actionLog.push(`Generated responsive srcset for ${imagesWithSrcset} image(s).`);
+                const format = effectiveOptions.convertToAvif ? 'AVIF'
+                             : (effectiveOptions.optimizeImages ? 'WebP' : 'modern formats');
+                const message = effectiveOptions.addResponsiveSrcset
+                    ? `Generated responsive <picture> elements with ${format} sources for ${imagesWithSrcset} image(s).`
+                    : `Converted ${imagesWithSrcset} image(s) to use ${format} in <picture> elements.`;
+                actionLog.push(message);
                 detailedMetrics.imagesWithSrcset = imagesWithSrcset;
             }
-            if (dimensionsAdded > 0) actionLog.push(`Added dimensions to ${dimensionsAdded} image(s) to prevent layout shift.`);
-        }
-
-        if (effectiveOptions.optimizeImages) {
-            let convertedToWebpCount = 0;
-            let convertedToAvifCount = 0;
-            const cdnHosts = ['i0.wp.com', 'i1.wp.com', 'i2.wp.com', 'i3.wp.com', 'cloudinary.com', 'imgix.net'];
-            doc.querySelectorAll('img').forEach(img => {
-                let wasConverted = false;
-                const targetFormat = effectiveOptions.convertToAvif ? 'avif' : 'webp';
-                const convertUrl = (src: string | null): string | null => {
-                    if (!src || src.includes('.svg') || src.startsWith('data:')) return src;
-                    try {
-                        const url = new URL(src);
-                        if (cdnHosts.some(host => url.hostname.includes(host))) {
-                            if (!url.searchParams.has('format') || url.searchParams.get('format') !== targetFormat) {
-                                url.searchParams.set('format', targetFormat);
-                                wasConverted = true;
-                                return url.toString();
-                            }
-                        }
-                    } catch (e) { /* Ignore */ }
-                    return src;
-                };
-                const newSrc = convertUrl(img.getAttribute('src'));
-                if (newSrc) img.setAttribute('src', newSrc);
-                const srcset = img.getAttribute('srcset');
-                if (srcset) {
-                    const newSrcset = srcset.split(',').map(part => {
-                        const [url, desc] = part.trim().split(/\s+/);
-                        const newUrl = convertUrl(url);
-                        return `${newUrl} ${desc || ''}`.trim();
-                    }).join(', ');
-                    img.setAttribute('srcset', newSrcset);
-                }
-                if(wasConverted) {
-                    if (targetFormat === 'avif') convertedToAvifCount++;
-                    else convertedToWebpCount++;
-                }
-            });
-            if (convertedToAvifCount > 0) {
-                actionLog.push(`Converted ${convertedToAvifCount} image(s) to AVIF format.`);
-                detailedMetrics.imagesToAvif = convertedToAvifCount;
-            }
-            if (convertedToWebpCount > 0) {
-                actionLog.push(`Converted ${convertedToWebpCount} image(s) to WebP format.`);
-                detailedMetrics.imagesToWebP = convertedToWebpCount;
+            if (dimensionsAdded > 0) {
+                actionLog.push(`Added dimensions to ${dimensionsAdded} image(s) to prevent layout shift.`);
             }
         }
 
@@ -648,7 +697,11 @@ export const useCleaner = () => {
         let finalHtml = `<!DOCTYPE html>\n` + doc.documentElement.outerHTML;
 
         if (lazyElementsFound) {
-            finalHtml = finalHtml.replace('</body>', `${lazyLoadScript}</body>`);
+            let scriptsToInject = lazyLoadScript;
+            if (doc.querySelector('.lazy-image')) {
+                scriptsToInject += imageIntersectionObserverScript;
+            }
+            finalHtml = finalHtml.replace('</body>', `${scriptsToInject}</body>`);
         }
 
         const cleanedBytes = new TextEncoder().encode(finalHtml).length;


### PR DESCRIPTION
This commit enhances the image lazy loading functionality in the `useCleaner` hook, based on your instructions.

The following improvements have been made:

- **IntersectionObserver for Images**: A new script has been added to handle lazy loading of images using the `IntersectionObserver` API. This provides more control and better performance for loading images as they enter the viewport.

- **<picture> Element for Responsive Images**: The logic for handling responsive images has been refactored to use the `<picture>` element. This allows for serving modern image formats like WebP or AVIF to supported browsers, with fallbacks for older formats. The `srcset` attribute is used within `<source>` elements to provide different image sizes for different viewports.

- **Integration with Lazy Loading**: The `<picture>` element implementation is integrated with the new `IntersectionObserver`-based lazy loading. The `data-srcset` attribute is used on `<source>` elements, which is then moved to `srcset` when the image is about to be loaded.